### PR TITLE
Fix delete bracket

### DIFF
--- a/src/core/decoder/src/api.c
+++ b/src/core/decoder/src/api.c
@@ -138,7 +138,7 @@ static inline bool bitdepthMatchesExpected(Logger_t log, const BitDepth_t expect
 }
 /*-----------------------------------------------------------------------------*/
 
-VN_DEC_CORE_API const char* perseus_get_version(void) { return CoreVersionFull(); }
+VN_DEC_CORE_API const char* perseus_get_version(void) { return CoreVersionFull; }
 
 VN_DEC_CORE_API int VN_CALLCONV perseus_decoder_config_init(perseus_decoder_config* cfg)
 {


### PR DESCRIPTION
```
api.c:141:64: error: called object is not a function or function pointer
  141 | VN_DEC_CORE_API const char* perseus_get_version(void) { return CoreVersionFull(); }
      |                                                                ^~~~~~~~~~~~~~~
```