### PR TITLE
Delete fmt::format&fmt::print for C⁺⁺17

### DIFF
--- a/src/utility/include/LCEVC/utility/types.h
+++ b/src/utility/include/LCEVC/utility/types.h
@@ -30,6 +30,8 @@
 
 // Implementations of {fmt} specific formatters for types
 //
+#if __MINGW32__ && (__cplusplus >= 201907L)
 #include "LCEVC/utility/types_fmt.h"
+#endif
 
 #endif

--- a/src/utility/src/base_decoder.cpp
+++ b/src/utility/src/base_decoder.cpp
@@ -9,7 +9,6 @@
  * DISTRIBUTION, WHETHER STAND-ALONE OR AS PART OF ANY OTHER PROJECT, REMAINS SUBJECT TO THE
  * EXCLUSION OF PATENT LICENSES PROVISION OF THE BSD-3-CLAUSE-CLEAR LICENSE. */
 
-#include <fmt/core.h>
 #include <LCEVC/utility/base_decoder.h>
 #include <LCEVC/utility/picture_lock.h>
 

--- a/src/utility/src/base_decoder_bin.cpp
+++ b/src/utility/src/base_decoder_bin.cpp
@@ -15,7 +15,9 @@
 #include "LCEVC/utility/picture_layout.h"
 #include "LCEVC/utility/raw_reader.h"
 
+#if __MINGW32__ && (__cplusplus >= 202207L)
 #include <fmt/core.h>
+#endif
 
 #include <iterator>
 #include <set>
@@ -198,12 +200,20 @@ bool BaseDecoderBin::probe(std::string_view binFile)
     }
 
     if (timestamps.empty()) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print("base_decoder_bin: probe found empty BIN file.\n");
+#else
+        printf("base_decoder_bin: probe found empty BIN file.\n");
+#endif
         return false;
     }
 
     if (timestamps.size() != count) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print("base_decoder_bin: probe found duplicate timestamps in BIN file.\n");
+#else
+        printf("base_decoder_bin: probe found empty BIN file.\n");
+#endif
         return false;
     }
 
@@ -220,7 +230,11 @@ bool BaseDecoderBin::probe(std::string_view binFile)
     int64_t testTimestamp = m_timestampStart;
     for (const auto ts : timestamps) {
         if (ts != testTimestamp) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
             fmt::print("base_decoder_bin: warning: probe found missing timestamp {}.\n", ts);
+#else
+            printf("base_decoder_bin: warning: probe found missing timestamp %lld.\n", (int64_t)ts);
+#endif
             break;
         }
         testTimestamp += m_timestampStep;

--- a/src/utility/src/bin_reader.cpp
+++ b/src/utility/src/bin_reader.cpp
@@ -16,7 +16,9 @@
 #include "bin_format.h"
 #include "LCEVC/utility/byte_order.h"
 
+#if __MINGW32__ && (__cplusplus >= 202207L)
 #include <fmt/core.h>
+#endif
 
 #include <algorithm>
 #include <fstream>
@@ -33,12 +35,20 @@ bool BinReader::readHeader()
     char magic[8] = {};
     uint32_t version = 0;
     if (!m_stream->read(magic, sizeof(magic)) || !readBigEndian(*m_stream, version)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Short BIN header.");
+#else
+        fprintf(stderr, "Short BIN header.");
+#endif
         return false;
     }
 
     if (std::memcmp(magic, kMagicBytes, sizeof(magic)) != 0 || version != kVersion) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Bad BIN header.");
+#else
+        fprintf(stderr, "Bad BIN header.");
+#endif
         return false;
     }
 
@@ -57,18 +67,30 @@ bool BinReader::read(int64_t& decodeIndex, int64_t& presentationIndex, std::vect
     }
 
     if (!readBigEndian(*m_stream, size)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Short BIN block.");
+#else
+        fprintf(stderr, "Short BIN block.");
+#endif
         return false;
     }
 
     // Payload header
     if (type != static_cast<uint16_t>(BlockTypes::LCEVCPayload) || size < 16) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Unrecognized BIN block.");
+#else
+        fprintf(stderr, "Unrecognized BIN block.");
+#endif
         return false;
     }
 
     if (!readBigEndian(*m_stream, decodeIndex) || !readBigEndian(*m_stream, presentationIndex)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Short Payload block.");
+#else
+        fprintf(stderr, "Short Payload block.");
+#endif
         return false;
     }
 
@@ -77,7 +99,11 @@ bool BinReader::read(int64_t& decodeIndex, int64_t& presentationIndex, std::vect
     char* data = static_cast<char*>(static_cast<void*>(payload.data()));
     auto sz = static_cast<std::streamsize>(payload.size());
     if (!m_stream->read(data, sz)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Short payload.");
+#else
+        fprintf(stderr, "Short payload.");
+#endif
         return false;
     }
 

--- a/src/utility/src/bin_writer.cpp
+++ b/src/utility/src/bin_writer.cpp
@@ -16,8 +16,6 @@
 #include "bin_format.h"
 #include "LCEVC/utility/byte_order.h"
 
-#include <fmt/core.h>
-
 #include <algorithm>
 #include <fstream>
 #include <ios>

--- a/src/utility/src/check.cpp
+++ b/src/utility/src/check.cpp
@@ -13,12 +13,18 @@
 
 #include "LCEVC/utility/types.h"
 
+#if __MINGW32__ && (__cplusplus >= 202207L)
 #include <fmt/core.h>
+#endif
 
 void LCEVC_CheckFn(const char* file, int line, const char* expr, LCEVC_ReturnCode r)
 {
     if (r != LCEVC_Success) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "{}:{} '{}' failed: {}\n", file, line, expr, r);
+#else
+        fprintf(stderr, "%s:%d '%s' failed: %s\n", file, line, expr, (const char*)r);
+#endif
         std::exit(EXIT_FAILURE);
     }
 }
@@ -30,7 +36,11 @@ bool LCEVC_AgainFn(const char* file, int line, const char* expr, LCEVC_ReturnCod
     }
 
     if (r != LCEVC_Success) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "{}:{} '{}' failed: {}\n", file, line, expr, r);
+#else
+        fprintf(stderr, "%s:%d '%s' failed: %s\n", file, line, expr, (const char*)r);
+#endif
         std::exit(EXIT_FAILURE);
     }
 
@@ -41,9 +51,15 @@ void utilityCheckFn(const char* file, int line, const char* expr, bool r, const 
 {
     if (!r) {
         if (strcmp(msg, "") == 0) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
             fmt::print(stderr, "{}:{} '{}' returned {}\n", file, line, expr, r);
         } else {
             fmt::print(stderr, "{}:{} '{}' failed: {}\n", file, line, expr, msg);
+#else
+            fprintf(stderr, "%s:%d '%s' returned %s\n", file, line, expr, (const char*)r);
+        } else {
+            fprintf(stderr, "%s:%d '%s' failed: %s\n", file, line, expr, msg);
+#endif
         }
         std::exit(EXIT_FAILURE);
     }

--- a/src/utility/src/configure.cpp
+++ b/src/utility/src/configure.cpp
@@ -13,7 +13,9 @@
 
 #include "LCEVC/lcevc_dec.h"
 
+#if __MINGW32__ && (__cplusplus >= 202207L)
 #include <fmt/core.h>
+#endif
 #include <rapidjson/document.h>
 
 #include <algorithm>
@@ -172,7 +174,11 @@ LCEVC_ReturnCode configureDecoderFromJson(LCEVC_DecoderHandle decoderHandle, std
         }
 
         if (ret != LCEVC_NotFound && ret != LCEVC_Success) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
             fmt::print("Unknown parameter '{}'\n", item->name.GetString());
+#else
+            printf("Unknown parameter '%s'\n", item->name);
+#endif
             return ret;
         }
     }

--- a/src/utility/src/parse_raw_name.cpp
+++ b/src/utility/src/parse_raw_name.cpp
@@ -17,7 +17,7 @@
 #include "LCEVC/utility/string_utils.h"
 
 #if __MINGW32__ && (__cplusplus >= 202207L)
-#include "../fmt/core.h"
+#include <fmt/core.h>
 #endif
 
 #include <regex>

--- a/src/utility/src/parse_raw_name.cpp
+++ b/src/utility/src/parse_raw_name.cpp
@@ -16,7 +16,9 @@
 #include "LCEVC/utility/check.h"
 #include "LCEVC/utility/string_utils.h"
 
-#include <fmt/core.h>
+#if __MINGW32__ && (__cplusplus >= 202207L)
+#include "../fmt/core.h"
+#endif
 
 #include <regex>
 
@@ -104,7 +106,11 @@ LCEVC_PictureDesc parseRawName(std::string_view name, float& rate)
 
     LCEVC_PictureDesc pictureDescription{};
     if (colorFormat == LCEVC_ColorFormat_Unknown) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print("parse_raw_name: Couldn't deduce format from filename\n");
+#else
+        printf("parse_raw_name: Couldn't deduce format from filename\n");
+#endif
         return pictureDescription;
     }
 

--- a/src/utility/src/picture_functions.cpp
+++ b/src/utility/src/picture_functions.cpp
@@ -13,7 +13,6 @@
 //
 #include <LCEVC/utility/picture_functions.h>
 //
-#include <fmt/core.h>
 #include <LCEVC/lcevc_dec.h>
 #include <LCEVC/utility/check.h>
 #include <LCEVC/utility/picture_layout.h>

--- a/src/utility/src/picture_layout.cpp
+++ b/src/utility/src/picture_layout.cpp
@@ -15,7 +15,7 @@
 #include "math_utils.h"
 
 #if __MINGW32__ && (__cplusplus >= 201907L)
-#include "../fmt/core.h"
+#include <fmt/core.h>
 #endif
 #include <LCEVC/utility/picture_layout.h>
 

--- a/src/utility/src/picture_layout.cpp
+++ b/src/utility/src/picture_layout.cpp
@@ -14,7 +14,9 @@
 #include "LCEVC/utility/check.h"
 #include "math_utils.h"
 
-#include <fmt/core.h>
+#if __MINGW32__ && (__cplusplus >= 201907L)
+#include "../fmt/core.h"
+#endif
 #include <LCEVC/utility/picture_layout.h>
 
 #include <cassert>
@@ -290,7 +292,13 @@ uint32_t PictureLayout::planeGroups() const
 // Construct a vooya/YUView style filename from base
 std::string PictureLayout::makeRawFilename(std::string_view name) const
 {
+#if __MINGW32__ && (__cplusplus >= 201907L)
     return fmt::format("{}_{}x{}{}", name, width(), height(), m_layoutInfo->suffix);
+#else
+    std::string s = {name.begin(), name.end()};
+    return std::string(s+"_"+std::to_string(width())+"x"+\
+                       std::to_string(height())+m_layoutInfo->suffix);
+#endif
 }
 
 } // namespace lcevc_dec::utility

--- a/src/utility/src/string_utils.cpp
+++ b/src/utility/src/string_utils.cpp
@@ -13,7 +13,9 @@
 //
 #include "LCEVC/utility/string_utils.h"
 
+#if __MINGW32__ && (__cplusplus >= 201907L)
 #include <fmt/core.h>
+#endif
 
 #include <algorithm>
 #include <cctype>
@@ -92,11 +94,19 @@ std::string hexDump(const uint8_t* data, uint32_t size, uint32_t offset)
     result.reserve(size * outputCharsByte + (size / bytesPerLine) * outputCharsPerLine);
 
     for (uint64_t line = 0; line < size; line += bytesPerLine) {
+#if __MINGW32__ && (__cplusplus >= 201907L)
         result += fmt::format("{:#06x} : ", offset + line);
+#else
+        result += std::string(std::to_string(offset + line));
+#endif
         // Bytes
         for (uint64_t byte = 0; byte < bytesPerLine; ++byte) {
             if (line + byte < size) {
+#if __MINGW32__ && (__cplusplus >= 201907L)
                 result += fmt::format("{:02x} ", data[line + byte]);
+#else
+                result += std::string(std::to_string(data[line + byte]));
+#endif
             } else {
                 result += "-- ";
             }

--- a/src/utility/src/types_cli11.cpp
+++ b/src/utility/src/types_cli11.cpp
@@ -15,14 +15,20 @@
 #include "LCEVC/utility/types_convert.h"
 #include "LCEVC/utility/types_stream.h"
 
+#if __MINGW32__ && (__cplusplus >= 202207L)
 #include <fmt/core.h>
+#endif
 
 using namespace lcevc_dec::utility;
 
 bool lexical_cast(const std::string& input, LCEVC_ColorFormat& v) // NOLINT
 {
     if (!fromString(input, v)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Not a valid ColorFormat: '{}'\n", input);
+#else
+        fprintf(stderr, "Not a valid ColorFormat: '%s'\n", input.c_str());
+#endif
         std::exit(EXIT_FAILURE);
     }
 
@@ -32,7 +38,11 @@ bool lexical_cast(const std::string& input, LCEVC_ColorFormat& v) // NOLINT
 bool lexical_cast(const std::string& input, LCEVC_ReturnCode& v) // NOLINT
 {
     if (!fromString(input, v)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Not a valid ReturnCode: '{}'\n", input);
+#else
+        fprintf(stderr, "Not a valid ReturnCode: '%s'\n", input.c_str());
+#endif
         std::exit(EXIT_FAILURE);
     }
 
@@ -42,7 +52,11 @@ bool lexical_cast(const std::string& input, LCEVC_ReturnCode& v) // NOLINT
 bool lexical_cast(const std::string& input, LCEVC_ColorRange& v) // NOLINT
 {
     if (!fromString(input, v)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Not a valid ColorRange: '{}'\n", input);
+#else
+        fprintf(stderr, "Not a valid ColorRange: '%s'\n", input.c_str());
+#endif
         std::exit(EXIT_FAILURE);
     }
 
@@ -52,7 +66,11 @@ bool lexical_cast(const std::string& input, LCEVC_ColorRange& v) // NOLINT
 bool lexical_cast(const std::string& input, LCEVC_ColorPrimaries& v) // NOLINT
 {
     if (!fromString(input, v)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Not a valid ColorPrimaries: '{}'\n", input);
+#else
+        fprintf(stderr, "Not a valid ColorPrimaries: '%s'\n", input.c_str());
+#endif
         std::exit(EXIT_FAILURE);
     }
 
@@ -62,7 +80,11 @@ bool lexical_cast(const std::string& input, LCEVC_ColorPrimaries& v) // NOLINT
 bool lexical_cast(const std::string& input, LCEVC_TransferCharacteristics& v) // NOLINT
 {
     if (!fromString(input, v)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Not a valid ColorTransfer: '{}'\n", input);
+#else
+        fprintf(stderr, "Not a valid ColorTransfer: '%s'\n", input.c_str());
+#endif
         std::exit(EXIT_FAILURE);
     }
 
@@ -72,7 +94,11 @@ bool lexical_cast(const std::string& input, LCEVC_TransferCharacteristics& v) //
 bool lexical_cast(const std::string& input, LCEVC_PictureFlag& v) // NOLINT
 {
     if (!fromString(input, v)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Not a valid PictureFlag: '{}'\n", input);
+#else
+        fprintf(stderr, "Not a valid PictureFlag: '%s'\n", input.c_str());
+#endif
         std::exit(EXIT_FAILURE);
     }
 
@@ -82,7 +108,11 @@ bool lexical_cast(const std::string& input, LCEVC_PictureFlag& v) // NOLINT
 bool lexical_cast(const std::string& input, LCEVC_Access& v) // NOLINT
 {
     if (!fromString(input, v)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Not a valid ColorFormat: '{}'\n", input);
+#else
+        fprintf(stderr, "Not a valid ColorFormat: '%s'\n", input.c_str());
+#endif
         std::exit(EXIT_FAILURE);
     }
 
@@ -92,7 +122,11 @@ bool lexical_cast(const std::string& input, LCEVC_Access& v) // NOLINT
 bool lexical_cast(const std::string& input, LCEVC_Event& v) // NOLINT
 {
     if (!fromString(input, v)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Not a valid Event: '{}'\n", input);
+#else
+        fprintf(stderr, "Not a valid Event: '%s'\n", input.c_str());
+#endif
         std::exit(EXIT_FAILURE);
     }
 

--- a/src/utility/src/types_stream.cpp
+++ b/src/utility/src/types_stream.cpp
@@ -13,7 +13,9 @@
 
 #include "LCEVC/utility/types_convert.h"
 
+#if __MINGW32__ && (__cplusplus >= 202207L)
 #include <fmt/core.h>
+#endif
 
 using namespace lcevc_dec::utility;
 
@@ -23,7 +25,11 @@ std::istream& operator>>(std::istream& in, LCEVC_ColorFormat& v)
     in >> str;
 
     if (!fromString(str.c_str(), v)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Not a valid ColorFormat: '{}'\n", str);
+#else
+        fprintf(stderr, "Not a valid ColorFormat: '%s'\n", str.c_str());
+#endif
         std::exit(EXIT_FAILURE);
     }
 
@@ -36,7 +42,11 @@ std::istream& operator>>(std::istream& in, LCEVC_ReturnCode& v)
     in >> str;
 
     if (!fromString(str.c_str(), v)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Not a valid ReturnCode: '{}'\n", str);
+#else
+        fprintf(stderr, "Not a valid ReturnCode: '%s'\n", str.c_str());
+#endif
         std::exit(EXIT_FAILURE);
     }
 
@@ -49,7 +59,11 @@ std::istream& operator>>(std::istream& in, LCEVC_ColorRange& v)
     in >> str;
 
     if (!fromString(str.c_str(), v)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Not a valid ColorRange: '{}'\n", str);
+#else
+        fprintf(stderr, "Not a valid ColorRange: '%s'\n", str.c_str());
+#endif
         std::exit(EXIT_FAILURE);
     }
 
@@ -62,7 +76,11 @@ std::istream& operator>>(std::istream& in, LCEVC_ColorPrimaries& v)
     in >> str;
 
     if (fromString(str.c_str(), v)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Not a valid ColorPrimaries: '{}'\n", str);
+#else
+        fprintf(stderr, "Not a valid ColorPrimaries: '%s'\n", str.c_str());
+#endif
         std::exit(EXIT_FAILURE);
     }
 
@@ -75,7 +93,11 @@ std::istream& operator>>(std::istream& in, LCEVC_TransferCharacteristics& v)
     in >> str;
 
     if (fromString(str.c_str(), v)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Not a valid ColorTransfer: '{}'\n", str);
+#else
+        fprintf(stderr, "Not a valid ColorTransfer: '%s'\n", str.c_str());
+#endif
         std::exit(EXIT_FAILURE);
     }
 
@@ -88,7 +110,11 @@ std::istream& operator>>(std::istream& in, LCEVC_PictureFlag& v)
     in >> str;
 
     if (fromString(str.c_str(), v)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Not a valid PictureFlag: '{}'\n", str);
+#else
+        fprintf(stderr, "Not a valid PictureFlag: '%s'\n", str.c_str());
+#endif
         std::exit(EXIT_FAILURE);
     }
 
@@ -101,7 +127,11 @@ std::istream& operator>>(std::istream& in, LCEVC_Access& v)
     in >> str;
 
     if (fromString(str.c_str(), v)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Not a valid Access: '{}'\n", str);
+#else
+        fprintf(stderr, "Not a valid Access: '%s'\n", str.c_str());
+#endif
         std::exit(EXIT_FAILURE);
     }
 
@@ -114,7 +144,11 @@ std::istream& operator>>(std::istream& in, LCEVC_Event& v)
     in >> str;
 
     if (fromString(str.c_str(), v)) {
+#if __MINGW32__ && (__cplusplus >= 202207L)
         fmt::print(stderr, "Not a valid Event: '{}'\n", str);
+#else
+        fprintf(stderr, "Not a valid Event: '%s'\n", str.c_str());
+#endif
         std::exit(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
This is an attempt to solve the problem of merging lcenc under ffmpeg in gcc 11.5.0 C⁺⁺17 for amateurs. For GNU 15.0.0 20241020 there is already std::format and std::prrint for me I don't recommend. You have to be able to convert and know what new -f`XXX` functions to add for GNU 15.0.0 to work properly.