### PR TITLE
src/api/src/buffer_manager.h: fix `gcc-15` build

### DIFF
--- a/src/api/src/buffer_manager.h
+++ b/src/api/src/buffer_manager.h
@@ -15,6 +15,7 @@
 #ifndef VN_API_BUFFER_MANAGER_H_
 #define VN_API_BUFFER_MANAGER_H_
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <set>


### PR DESCRIPTION
`gcc-15` removed a few transitive header inclusions in it's standard library and exposed missing includes in downstream progects.

Without the change `LCEVCdec` fails the build as:

    In file included from /build/source/src/api/src/buffer_manager.cpp:15:
    src/api/src/buffer_manager.h:25:35: error: 'uint8_t' was not declared in this scope
       25 | using PictureBuffer = std::vector<uint8_t>;
          |                                   ^~~~~~~
    src/api/src/buffer_manager.h:21:1: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
       20 | #include <set>
      +++ |+#include <cstdint>
       21 |