### PR TITLE
Build fixes for Windows and more

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) V-Nova International Limited 2022-2025. All rights reserved.
+# Copyright (c) V-Nova International Limited 2023-2025. All rights reserved.
 # This software is licensed under the BSD-3-Clause-Clear License by V-Nova Limited.
 # No patent licenses are granted under this license. For enquiries about patent licenses,
 # please contact legal@v-nova.com.
@@ -125,12 +125,11 @@ configure_file("cmake/templates/lcevc_dec.pc.in" "generated/lcevc_dec.pc" @ONLY)
 
 # Top level install
 #
-install(FILES "COPYING" DESTINATION "licenses")
+install(FILES "COPYING" DESTINATION "${CMAKE_INSTALL_DOCDIR}/licenses")
 install(FILES "${CMAKE_BINARY_DIR}/install_config/README.md" DESTINATION "${CMAKE_INSTALL_DOCDIR}")
 install(FILES "${CMAKE_BINARY_DIR}/generated/lcevc_dec.pc"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
-install(DIRECTORY "licenses" DESTINATION "./")
-install(FILES "LICENSE.md" DESTINATION "licenses/LCEVCdec")
+install(FILES "LICENSE.md" DESTINATION "${CMAKE_INSTALL_DOCDIR}/licenses")
 
 #
 if (NOT CMAKE_INSTALL_INCLUDEDIR)

--- a/cmake/modules/VNovaProject.cmake
+++ b/cmake/modules/VNovaProject.cmake
@@ -106,3 +106,33 @@ message(
 include("Arch/${TARGET_ARCH}" OPTIONAL)
 include("Platform/${TARGET_PLATFORM}")
 include("Compiler/${TARGET_COMPILER}")
+
+if (NOT BUILD_SHARED_LIBS)
+    if (CMAKE_SYSTEM_NAME STREQUAL "Android")
+      set(PC_EXTRA_LIBS "-lc++ -llog")
+    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        set(PC_EXTRA_LIBS "-lstdc++")
+    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        # Further check if libc++ is used instead of libstdc++
+        include(CheckCXXSourceCompiles)
+        check_cxx_source_compiles(
+            "
+        #include <cstddef>
+        int main() {
+            #if defined(_LIBCPP_VERSION)
+            return 0;
+            #else
+            return 1;
+            #endif
+        }"
+            USING_LIBCXX)
+
+        if (USING_LIBCXX)
+            set(PC_EXTRA_LIBS "-lc++")
+        else ()
+            set(PC_EXTRA_LIBS "-lstdc++")
+        endif ()
+    endif ()
+endif ()
+
+set(PC_EXTRA_LIBS "${PC_EXTRA_LIBS} -lm")

--- a/cmake/modules/VNovaProject.cmake
+++ b/cmake/modules/VNovaProject.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) V-Nova International Limited 2022-2025. All rights reserved.
+# Copyright (c) V-Nova International Limited 2023-2025. All rights reserved.
 # This software is licensed under the BSD-3-Clause-Clear License by V-Nova Limited.
 # No patent licenses are granted under this license. For enquiries about patent licenses,
 # please contact legal@v-nova.com.
@@ -14,13 +14,6 @@
 
 # Target specific configuration - included automatically after project()
 #
-
-# Default install dir is <build>/install
-if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    set(CMAKE_INSTALL_PREFIX
-        "install"
-        CACHE PATH "Install directory" FORCE)
-endif ()
 
 # Architecture
 #

--- a/cmake/modules/VNovaSetup.cmake
+++ b/cmake/modules/VNovaSetup.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) V-Nova International Limited 2022-2025. All rights reserved.
+# Copyright (c) V-Nova International Limited 2023-2025. All rights reserved.
 # This software is licensed under the BSD-3-Clause-Clear License by V-Nova Limited.
 # No patent licenses are granted under this license. For enquiries about patent licenses,
 # please contact legal@v-nova.com.

--- a/cmake/templates/lcevc_dec.pc.in
+++ b/cmake/templates/lcevc_dec.pc.in
@@ -6,5 +6,5 @@ Name: lcevc_dec
 Description: LCEVC Decoder SDK
 Version: @GIT_SHORT_VERSION@
 Libs: -L"${libdir}" -llcevc_dec_api
-Libs.private: -lpthread -llcevc_dec_core
+Libs.private: -lpthread
 Cflags: -I"${includedir}"

--- a/cmake/templates/lcevc_dec.pc.in
+++ b/cmake/templates/lcevc_dec.pc.in
@@ -5,6 +5,5 @@ includedir=${prefix}/include
 Name: lcevc_dec
 Description: LCEVC Decoder SDK
 Version: @GIT_SHORT_VERSION@
-Libs: -L"${libdir}" -llcevc_dec_api
-Libs.private: -lpthread
+Libs: -L"${libdir}" @PC_EXTRA_LIBS@ -llcevc_dec_api
 Cflags: -I"${includedir}"

--- a/cmake/templates/lcevc_dec.pc.in
+++ b/cmake/templates/lcevc_dec.pc.in
@@ -1,4 +1,4 @@
-prefix=${pcfiledir}/../..
+prefix=@CMAKE_INSTALL_PREFIX@
 libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 includedir=${prefix}/include
 

--- a/cmake/tools/lint.py
+++ b/cmake/tools/lint.py
@@ -333,7 +333,7 @@ def main():
                   f"{process.stdout.decode('utf-8')}")
             errors += 1
     else:
-        autopep_exe = find_formatter('autopep8', '2.3.1')
+        autopep_exe = find_formatter('autopep8', '2.3')
         python_files = get_paths(PYTHON_TYPES, changed_files)
         if python_files:
             process = run_cmd([autopep_exe, '-i', '--global-config', '.flake8'] + python_files)

--- a/cmake/tools/lint.py
+++ b/cmake/tools/lint.py
@@ -65,7 +65,7 @@ def get_changed_files(diff_master=False):
         target_branch = os.environ.get('TARGET_BRANCH', 'master')
         print(f'Getting file diff from "{current_branch}" to "{target_branch}"')
         process = run_cmd(['git', 'diff', '--name-only', '--diff-filter=ACMRTUX',
-                           f'origin/{current_branch}', f'origin/{target_branch}'])
+                           f'{current_branch}', f'origin/{target_branch}'])
         changed_files = process.stdout.decode('utf-8').splitlines()
     else:
         process = run_cmd(['git', 'ls-files', '--modified'])

--- a/src/api/src/log.cpp
+++ b/src/api/src/log.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) V-Nova International Limited 2023-2025. All rights reserved.
+/* Copyright (c) V-Nova International Limited 2024-2025. All rights reserved.
  * This software is licensed under the BSD-3-Clause-Clear License by V-Nova Limited.
  * No patent licenses are granted under this license. For enquiries about patent licenses,
  * please contact legal@v-nova.com.
@@ -23,7 +23,7 @@
 #endif
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include <cstddef>

--- a/src/api/src/log.h
+++ b/src/api/src/log.h
@@ -1,4 +1,4 @@
-/* Copyright (c) V-Nova International Limited 2023-2024. All rights reserved.
+/* Copyright (c) V-Nova International Limited 2024-2025. All rights reserved.
  * This software is licensed under the BSD-3-Clause-Clear License by V-Nova Limited.
  * No patent licenses are granted under this license. For enquiries about patent licenses,
  * please contact legal@v-nova.com.
@@ -17,6 +17,7 @@
 
 #include <array>
 #include <cstdarg>
+#include <cstdint>
 #include <cstdio>
 #include <string>
 

--- a/src/api_utility/CMakeLists.txt
+++ b/src/api_utility/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) V-Nova International Limited 2025. All rights reserved.
+# Copyright (c) V-Nova International Limited 2024-2025. All rights reserved.
 # This software is licensed under the BSD-3-Clause-Clear License by V-Nova Limited.
 # No patent licenses are granted under this license. For enquiries about patent licenses,
 # please contact legal@v-nova.com.
@@ -14,7 +14,7 @@
 
 include("Sources.cmake")
 
-add_library(lcevc_dec_api_utility STATIC ${SOURCES} ${HEADERS} ${INTERFACES})
+add_library(lcevc_dec_api_utility OBJECT ${SOURCES} ${HEADERS} ${INTERFACES})
 lcevc_set_properties(lcevc_dec_api_utility)
 
 target_include_directories(lcevc_dec_api_utility PUBLIC "${CMAKE_CURRENT_LIST_DIR}/include")

--- a/src/api_utility/include/LCEVC/api_utility/threading.h
+++ b/src/api_utility/include/LCEVC/api_utility/threading.h
@@ -1,4 +1,4 @@
-/* Copyright (c) V-Nova International Limited 2025. All rights reserved.
+/* Copyright (c) V-Nova International Limited 2024-2025. All rights reserved.
  * This software is licensed under the BSD-3-Clause-Clear License by V-Nova Limited.
  * No patent licenses are granted under this license. For enquiries about patent licenses,
  * please contact legal@v-nova.com.
@@ -18,7 +18,7 @@
 #include <string_view>
 
 #if defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 #define VNThreadLocal __declspec(thread)
 #define VN_TO_THREAD_NAME(x) L##x
 #else

--- a/src/api_utility/src/math_utils.h
+++ b/src/api_utility/src/math_utils.h
@@ -17,13 +17,15 @@
 #ifndef VN_LCEVC_UTILITY_MATH_UTILS_H
 #define VN_LCEVC_UTILITY_MATH_UTILS_H
 
+#include "lcevc_config.h"
+
 #include <algorithm>
 #include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>
 
-#if defined WIN32
+#if VN_COMPILER(MSVC)
 #include <intrin.h>
 #endif
 
@@ -33,9 +35,9 @@ namespace lcevc_dec::utility {
 //
 static inline uint8_t clz(uint32_t n)
 {
-#if defined WIN32
+#if VN_COMPILER(MSVC)
     return (uint8_t)(_lzcnt_u32(n));
-#elif defined __linux__ && (__GNUC__ >= 14)
+#elif defined(__GNUC__) && (__GNUC__ >= 14)
     return (uint8_t)(__builtin_clzg(n, (int)(8 * sizeof(n))));
 #else
     if (n == 0) {

--- a/src/api_utility/src/threading.cpp
+++ b/src/api_utility/src/threading.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) V-Nova International Limited 2025. All rights reserved.
+/* Copyright (c) V-Nova International Limited 2024-2025. All rights reserved.
  * This software is licensed under the BSD-3-Clause-Clear License by V-Nova Limited.
  * No patent licenses are granted under this license. For enquiries about patent licenses,
  * please contact legal@v-nova.com.
@@ -22,7 +22,7 @@
 #include <direct.h>
 #include <io.h>
 #include <processthreadsapi.h>
-#include <Windows.h>
+#include <windows.h>
 #define stat _stat
 #else
 #ifdef __ANDROID__

--- a/src/core/decoder/CMakeLists.txt
+++ b/src/core/decoder/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) V-Nova International Limited 2022-2025. All rights reserved.
+# Copyright (c) V-Nova International Limited 2023-2025. All rights reserved.
 # This software is licensed under the BSD-3-Clause-Clear License by V-Nova Limited.
 # No patent licenses are granted under this license. For enquiries about patent licenses,
 # please contact legal@v-nova.com.
@@ -48,7 +48,7 @@ add_library(lcevc_dec::core_static ALIAS lcevc_dec_core_static)
 
 # -------------------------------------------------------------------------------
 
-add_library(lcevc_dec_core)
+add_library(lcevc_dec_core OBJECT)
 lcevc_set_properties(lcevc_dec_core)
 
 target_sources(lcevc_dec_core PRIVATE ${SOURCES})

--- a/src/core/decoder/src/common/platform.h
+++ b/src/core/decoder/src/common/platform.h
@@ -1,4 +1,4 @@
-/* Copyright (c) V-Nova International Limited 2022-2024. All rights reserved.
+/* Copyright (c) V-Nova International Limited 2023-2025. All rights reserved.
  * This software is licensed under the BSD-3-Clause-Clear License by V-Nova Limited.
  * No patent licenses are granted under this license. For enquiries about patent licenses,
  * please contact legal@v-nova.com.
@@ -56,7 +56,7 @@
 /*------------------------------------------------------------------------------
  * Thread local storage.
  *-----------------------------------------------------------------------------*/
-#if VN_OS(WINDOWS)
+#if VN_COMPILER(MSVC)
 #define VN_THREADLOCAL() __declspec(thread)
 #else
 #define VN_THREADLOCAL() __thread
@@ -70,7 +70,7 @@
  *
  * This would align some_array to a 16 byte boundary and default it to 0.
  *-----------------------------------------------------------------------------*/
-#if VN_OS(WINDOWS)
+#if VN_COMPILER(MSVC)
 #define VN_ALIGN(v, a) __declspec(align(a)) v
 #else
 #define VN_ALIGN(v, a) v __attribute__((aligned(a)))

--- a/src/core/decoder/src/common/simd.c
+++ b/src/core/decoder/src/common/simd.c
@@ -1,4 +1,4 @@
-/* Copyright (c) V-Nova International Limited 2022-2024. All rights reserved.
+/* Copyright (c) V-Nova International Limited 2023-2025. All rights reserved.
  * This software is licensed under the BSD-3-Clause-Clear License by V-Nova Limited.
  * No patent licenses are granted under this license. For enquiries about patent licenses,
  * please contact legal@v-nova.com.
@@ -43,10 +43,8 @@ static CPUAccelerationFeatures_t detectX86Features(void) { return CAFSSE; }
 /*! \brief Helper function for loading CPUID. */
 static void loadCPUInfo(int32_t cpuInfo[4], int32_t field)
 {
-#if VN_OS(WINDOWS)
+#if VN_COMPILER(MSVC)
     __cpuid(cpuInfo, field);
-#elif (VN_OS(LINUX) || VN_OS(ANDROID)) && !VN_OS(BROWSER)
-    __cpuid_count(field, 0, cpuInfo[0], cpuInfo[1], cpuInfo[2], cpuInfo[3]);
 #elif VN_OS(MACOS) || VN_OS(IOS) || VN_OS(TVOS)
     __asm__ __volatile__("xchg %%ebx, %k[tempreg]\n\t"
                          "cpuid\n\t"
@@ -54,6 +52,8 @@ static void loadCPUInfo(int32_t cpuInfo[4], int32_t field)
                          : "=a"(cpuInfo[0]), [tempreg] "=&r"(cpuInfo[1]), "=c"(cpuInfo[2]),
                            "=d"(cpuInfo[3])
                          : "a"(field), "c"(0));
+#elif (VN_COMPILER(CLANG) || VN_COMPILER(GCC)) && !VN_OS(BROWSER)
+    __cpuid_count(field, 0, cpuInfo[0], cpuInfo[1], cpuInfo[2], cpuInfo[3]);
 #elif !VN_OS(BROWSER)
 #error "Unsupported platform for CPUID"
 #endif

--- a/src/core/decoder/src/common/threading.c
+++ b/src/core/decoder/src/common/threading.c
@@ -1,4 +1,4 @@
-/* Copyright (c) V-Nova International Limited 2022-2024. All rights reserved.
+/* Copyright (c) V-Nova International Limited 2023-2025. All rights reserved.
  * This software is licensed under the BSD-3-Clause-Clear License by V-Nova Limited.
  * No patent licenses are granted under this license. For enquiries about patent licenses,
  * please contact legal@v-nova.com.
@@ -82,7 +82,7 @@ static void platformMutexCVWaitTimed(ThreadPlatform_t* platform, uint32_t millis
 #elif VN_CORE_FEATURE(WINTHREADS)
 
 #include <stdbool.h>
-#include <Windows.h>
+#include <windows.h>
 
 #define VN_THREADLOOP_SIGNATURE() static DWORD WINAPI threadLoop(LPVOID data)
 

--- a/src/core/decoder/src/common/time.c
+++ b/src/core/decoder/src/common/time.c
@@ -1,4 +1,4 @@
-/* Copyright (c) V-Nova International Limited 2023-2024. All rights reserved.
+/* Copyright (c) V-Nova International Limited 2023-2025. All rights reserved.
  * This software is licensed under the BSD-3-Clause-Clear License by V-Nova Limited.
  * No patent licenses are granted under this license. For enquiries about patent licenses,
  * please contact legal@v-nova.com.
@@ -18,7 +18,7 @@
 #include "context.h"
 
 #if VN_OS(WINDOWS)
-#include <Windows.h>
+#include <windows.h>
 #else
 #include <time.h>
 #endif

--- a/src/core/decoder/src/common/types.c
+++ b/src/core/decoder/src/common/types.c
@@ -1,4 +1,4 @@
-/* Copyright (c) V-Nova International Limited 2022-2025. All rights reserved.
+/* Copyright (c) V-Nova International Limited 2023-2025. All rights reserved.
  * This software is licensed under the BSD-3-Clause-Clear License by V-Nova Limited.
  * No patent licenses are granted under this license. For enquiries about patent licenses,
  * please contact legal@v-nova.com.
@@ -699,21 +699,6 @@ FixedPointDemotionFunction_t fixedPointGetDemotionFunction(FixedPoint_t unsigned
 }
 
 /*------------------------------------------------------------------------------*/
-
-size_t bitScanReverse(size_t value)
-{
-#if VN_OS(WINDOWS)
-    unsigned long result = 0;
-    _BitScanReverse64(&result, value);
-    return (size_t)result;
-#else
-    if (value == 0) {
-        return 0;
-    }
-
-    return 63 - __builtin_clzll((unsigned long long)value);
-#endif
-}
 
 bool isPow2(uint32_t value) { return (value & (value - 1)) == 0; }
 

--- a/src/core/decoder/src/common/types.h
+++ b/src/core/decoder/src/common/types.h
@@ -1,4 +1,4 @@
-/* Copyright (c) V-Nova International Limited 2022-2024. All rights reserved.
+/* Copyright (c) V-Nova International Limited 2023-2025. All rights reserved.
  * This software is licensed under the BSD-3-Clause-Clear License by V-Nova Limited.
  * No patent licenses are granted under this license. For enquiries about patent licenses,
  * please contact legal@v-nova.com.
@@ -514,14 +514,6 @@ static inline int32_t divideCeilS32(int32_t numerator, int32_t denominator)
 
     return (numerator + denominator - 1) / denominator;
 }
-
-/* Determines the bit index of the first non-zero bit from MSB to LSB.
- *
- * E.g. if value == 1 return 0.
- *      if value == 10 return 3.
- *
- * If the  value is 0 then 0 is returned. */
-size_t bitScanReverse(size_t value);
 
 /* Determines if a 32-bit unsigned value is a power of 2.
  *

--- a/src/core/decoder/src/decode/huffman.c
+++ b/src/core/decoder/src/decode/huffman.c
@@ -1,4 +1,4 @@
-/* Copyright (c) V-Nova International Limited 2022-2024. All rights reserved.
+/* Copyright (c) V-Nova International Limited 2023-2025. All rights reserved.
  * This software is licensed under the BSD-3-Clause-Clear License by V-Nova Limited.
  * No patent licenses are granted under this license. For enquiries about patent licenses,
  * please contact legal@v-nova.com.
@@ -19,6 +19,7 @@
 #include "common/platform.h"
 #include "common/types.h"
 #include "decode/deserialiser.h"
+#include "lcevc_config.h"
 
 #include <assert.h>
 #include <stdbool.h>
@@ -30,7 +31,7 @@
 
 static inline uint8_t clz(uint32_t streamData, uint8_t numBits)
 {
-#if defined WIN32
+#if VN_COMPILER(MSVC)
     return (uint8_t)(_lzcnt_u32(streamData) + numBits - 32);
 #elif VN_COMPILER(GCC) && (__GNUC__ >= 14)
     /* Annoyingly, it's undefined behaviour if you provide 0 to __builtin_clz. To match the Windows

--- a/src/core/sequencing/CMakeLists.txt
+++ b/src/core/sequencing/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 include("Sources.cmake")
 
-add_library(lcevc_dec_core_sequencing STATIC)
+add_library(lcevc_dec_core_sequencing OBJECT)
 add_library(lcevc_dec::sequencing ALIAS lcevc_dec_core_sequencing)
 lcevc_set_properties(lcevc_dec_core_sequencing)
 

--- a/src/overlay_images/CMakeLists.txt
+++ b/src/overlay_images/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) V-Nova International Limited 2022-2024. All rights reserved.
+# Copyright (c) V-Nova International Limited 2023-2025. All rights reserved.
 # This software is licensed under the BSD-3-Clause-Clear License by V-Nova Limited.
 # No patent licenses are granted under this license. For enquiries about patent licenses,
 # please contact legal@v-nova.com.
@@ -14,7 +14,7 @@
 
 include("Sources.cmake")
 
-add_library(lcevc_dec_overlay_images STATIC ${SOURCES})
+add_library(lcevc_dec_overlay_images OBJECT ${SOURCES})
 lcevc_set_properties(lcevc_dec_overlay_images)
 
 target_include_directories(lcevc_dec_overlay_images PUBLIC "${CMAKE_CURRENT_LIST_DIR}/include")

--- a/src/utility/src/get_program_dir.cpp
+++ b/src/utility/src/get_program_dir.cpp
@@ -21,7 +21,7 @@ namespace filesystem = std::filesystem;
 namespace lcevc_dec::utility {
 
 #if VN_OS(WINDOWS)
-#include <Windows.h>
+#include <windows.h>
 std::string getExecutablePath()
 {
     // Get executable name


### PR DESCRIPTION
Here are some more build fixes part of my effort to build LCEVCdec as part of the GStreamer packages.

They mostly center on not confusing "Windows" and "MSVC" as GStreamer builds Windows targets also using mingw.

Also fix the install the pkg-config to use the install prefix as the pkg-config path is different on Debian and RedHat style distributions. 

