### PR TITLE
Do not hardcode AVX when building x86_64

### DIFF
--- a/cmake/modules/Compiler/ClangApple.cmake
+++ b/cmake/modules/Compiler/ClangApple.cmake
@@ -13,7 +13,7 @@
 # THE EXCLUSION OF PATENT LICENSES PROVISION OF THE BSD-3-CLAUSE-CLEAR LICENSE.
 
 if (VN_SDK_SIMD AND TARGET_ARCH MATCHES "^x86")
-    target_compile_options(lcevc_dec::compiler INTERFACE -mavx)
+    target_compile_options(lcevc_dec::compiler INTERFACE -msse4.1)
 endif ()
 
 target_compile_options(

--- a/cmake/modules/Compiler/ClangGNU.cmake
+++ b/cmake/modules/Compiler/ClangGNU.cmake
@@ -13,7 +13,7 @@
 # THE EXCLUSION OF PATENT LICENSES PROVISION OF THE BSD-3-CLAUSE-CLEAR LICENSE.
 
 if (VN_SDK_SIMD AND TARGET_ARCH MATCHES "^x86")
-    target_compile_options(lcevc_dec::compiler INTERFACE -mavx)
+    target_compile_options(lcevc_dec::compiler INTERFACE -msse4.1)
 endif ()
 
 if (TARGET_ARCH STREQUAL "wasm")

--- a/cmake/modules/Compiler/GNU.cmake
+++ b/cmake/modules/Compiler/GNU.cmake
@@ -13,7 +13,7 @@
 # THE EXCLUSION OF PATENT LICENSES PROVISION OF THE BSD-3-CLAUSE-CLEAR LICENSE.
 
 if (VN_SDK_SIMD AND TARGET_ARCH MATCHES "^x86")
-    target_compile_options(lcevc_dec::compiler INTERFACE -mavx)
+    target_compile_options(lcevc_dec::compiler INTERFACE -msse4.1)
 endif ()
 
 if (VN_SDK_COVERAGE)

--- a/cmake/modules/Compiler/MSVC.cmake
+++ b/cmake/modules/Compiler/MSVC.cmake
@@ -13,7 +13,7 @@
 # THE EXCLUSION OF PATENT LICENSES PROVISION OF THE BSD-3-CLAUSE-CLEAR LICENSE.
 
 if (VN_SDK_SIMD AND TARGET_ARCH MATCHES "^x86")
-    target_compile_options(lcevc_dec::compiler INTERFACE /arch:AVX)
+    target_compile_options(lcevc_dec::compiler INTERFACE /arch:SSE2)
 endif ()
 
 target_compile_definitions(

--- a/src/legacy/decoder/src/common/simd.c
+++ b/src/legacy/decoder/src/common/simd.c
@@ -73,17 +73,8 @@ static CPUAccelerationFeatures_t detectAVX2Feature(const int32_t cpuInfo[4])
     static const int32_t kAVX2Flag = 1 << 5;
     static const int32_t kXSaveFlag = 1 << 27;
 
-    bool hasXSaveSupport = false;
-
-    /* Check for XSAVE support on the OS. */
-    if ((cpuInfo[2] & kXSaveFlag) == kXSaveFlag) {
-        static const uint32_t kOSXSaveMask = 6;
-        static const uint32_t kControlRegister = 0; /* _XCR_XFEATURE_ENABLED_MASK */
-        hasXSaveSupport = ((_xgetbv(kControlRegister) & kOSXSaveMask) == kOSXSaveMask);
-    }
-
-    /* Must have xsave feature and OS must support it. */
-    if (!hasXSaveSupport) {
+    /* Check for XSAVE support on the CPU. */
+    if ((cpuInfo[2] & kXSaveFlag) != kXSaveFlag) {
         return CAFNone;
     }
 
@@ -91,7 +82,12 @@ static CPUAccelerationFeatures_t detectAVX2Feature(const int32_t cpuInfo[4])
     int32_t info[4];
     loadCPUInfo(info, 7);
 
-    return ((info[1] & kAVX2Flag) == kAVX2Flag) ? CAFAVX2 : CAFNone;
+    /* Check if CPU supports AVX2. */
+    if ((info[1] & kAVX2Flag) != kAVX2Flag) {
+        return CAFNone;
+    }
+
+    return CAFAVX2;
 #else
     /* vndk does not define _xgetbv */
     return CAFNone;


### PR DESCRIPTION
Most distributions are actually compiled for `x86_64 v1`. Even when building on those platforms, the library is compiled with AVX, making it effectively `x86_64 v3`.

Add auto detection at runtime where missing.