### PR TITLE
Fix: error: 'nids' undeclared

### DIFF
--- a/src/common/src/acceleration.c
+++ b/src/common/src/acceleration.c
@@ -67,7 +67,7 @@ static bool detectAVX2(void)
 {
     int32_t cpuInfo[4];
     loadCPUInfo(cpuInfo, 0);
-    if (nids < 7) {
+    if (cpuInfo[0] < 7) {
         return false;
     }
     loadCPUInfo(cpuInfo, 1);


### PR DESCRIPTION
```
acceleration.c:71:9: error: 'nids' undeclared (first use in this function)
```