### PR TITLE
Fix: added <string>

### DIFF
--- a/src/pipeline/src/picture_layout.cpp
+++ b/src/pipeline/src/picture_layout.cpp
@@ -14,6 +14,8 @@
 
 #include <LCEVC/pipeline/picture_layout.hpp>
 
+#include <string>
+
 namespace lcevc_dec::pipeline {
 
 // Construct a vooya/YUView style filename from base


### PR DESCRIPTION
```
picture_layout.cpp:16:1: note: 'std::string' is defined in header '<string>'; this is probably fixable by adding '#include <string>'
   15 | #include "picture_layout.h"
  +++ |+#include <string>
```